### PR TITLE
increase compatibility with json.Number to avoid accuracy loss of int

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package yql_test
 import (
 	"fmt"
 
-	"github.com/caibirdme/yql"
+	"github.com/zcs-seu/yql"
 )
 
 func ExampleMatch() {

--- a/lambda/instruct.go
+++ b/lambda/instruct.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	grammar "github.com/caibirdme/yql/internal/lambda"
+	grammar "github.com/zcs-seu/yql/internal/lambda"
 )
 
 type action uint8

--- a/lambda/lambda.go
+++ b/lambda/lambda.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	grammar "github.com/caibirdme/yql/internal/lambda"
+	grammar "github.com/zcs-seu/yql/internal/lambda"
 )
 
 type bailLexer struct {

--- a/yql.go
+++ b/yql.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/caibirdme/yql/internal/grammar"
-	"github.com/caibirdme/yql/internal/stack"
+	"github.com/zcs-seu/yql/internal/grammar"
+	"github.com/zcs-seu/yql/internal/stack"
 )
 
 type boolStack interface {

--- a/yql.go
+++ b/yql.go
@@ -3,6 +3,7 @@ package yql
 import (
 	"fmt"
 	"strconv"
+	"encoding/json"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"github.com/caibirdme/yql/internal/grammar"
@@ -194,6 +195,16 @@ func compare(actualValue interface{}, expectValue []string, op string) bool {
 			return false
 		}
 		return cmpInt(actual, expect, op)
+	case json.Number:
+		actualValue, err := strconv.ParseInt(actualValue.(json.Number).String(), 10, 64)
+		if nil != err {
+			return false
+		}
+		expect, err := strconv.ParseInt(e, 10, 64)
+		if nil != err {
+			return false
+		}
+		return cmpInt(actualValue, expect, op)
 	case float64:
 		expect, err := strconv.ParseFloat(e, 64)
 		if nil != err {


### PR DESCRIPTION
Using encoding/json to marshal/unmarshal a map may cause accuracy loss of int. In terms of this condition, we can use json.Number to avoid. Now I update yql by adding compatibility with json.Number